### PR TITLE
Fix publicPath variable for Webpack v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var steed = require('steed');
 function resolveFile(loaderContext, require, callback) {
 
   var dirname = path.dirname(loaderContext.resourcePath);
-  var __webpack_public_path__ = loaderContext.options.output.publicPath || '';
+  var __webpack_public_path__ = loaderContext._compilation.options.output.publicPath || '';
 
   loaderContext.resolve(dirname, require.path, function(err, filename) {
     if (err) {


### PR DESCRIPTION
Hi there,

Thanks for this great loader.
I recently came across an issue with Webpack v2, and was wondering if you'd be open to this PR.

Cheers!

---

`loaderContext.options` is [no longer exposed](https://webpack.js.org/api/loaders/#deprecated-context-properties) and was causing build issues.

There doesn't seem to be a great way to access the `publicPath` variable, unless a user sets a `process.env` variable in their config file, and then we read from the loader. This is [demonstrated in the docs](https://webpack.js.org/guides/public-path/#set-value-on-build-time).

This would most likely be a stopgap measure, to ensure that current configurations work with Webpack 2. However it seems that [`_compilation` might be deprecated in the future](https://github.com/webpack/webpack/issues/250#issuecomment-246353404), so a configuration change could be unavoidable.

Either way, hope this helps others having similar issues.