### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/trutoo/nested-require-loader.git",
   "dependencies": {
     "ajv": "^5.2.2",
+    "loader-utils": "^1.1.0",
     "steed": "^1.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nested-require-loader",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Simply a nested require loader for webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I get "loaderUtils.getOptions is not a function" in my project. Adding `loader-utils` as a dependency fixes this error.

For some reason test runs fine without `loader-utils`, and worked fine for a while in my project. All of a sudden it decided that it needs `loader-utils` dependency.